### PR TITLE
Require unary operator functions to have one parameter

### DIFF
--- a/src/compiler/validation/fns.rs
+++ b/src/compiler/validation/fns.rs
@@ -17,6 +17,7 @@ impl Validator<'_, '_> {
         validators::item::check_circular_dependencies(ref_, dependency_result, &mut self.context)?;
         self.validate_params(&node.params)?;
         self.validate_fn_return_type(node)?;
+        validators::item::check_unary_operator_fn_params(node, &mut self.context, self.indexes)?;
         self.run_with_fn_constness(node.const_keyword_span.is_some(), |self_| {
             self_.validate_fn_statements(node)
         })?;

--- a/src/compiler/validation/validators/item.rs
+++ b/src/compiler/validation/validators/item.rs
@@ -1,11 +1,15 @@
 use crate::compiler::indexing::indexes::Indexes;
 use crate::compiler::indexing::item_ref::ItemRef;
+use crate::compiler::key_rendering::KeyRenderer;
+use crate::compiler::parsing::items::fns::FnDefinition;
 use crate::compiler::parsing::items::params::Param;
 use crate::compiler::prelude::PRELUDE_FILE_INDEX;
 use crate::utils::indexing::{ItemNodeRef, NodeRef, SearchConfig, SearchParams, Visibility};
 use crate::utils::parsing::span::{Span, SpanProps};
 use crate::utils::validation::{ValidateContext, ValidateError};
 use crate::{Log, LogInner, LogLevel};
+
+const UNARY_OPERATOR_FN_NAMES: &[&str] = &["__neg__", "__not__"];
 
 pub(crate) fn check_circular_dependencies(
     item: ItemRef<'_>,
@@ -199,6 +203,25 @@ pub(crate) fn check_found<'index>(
                     })
                     .collect()
             },
+        });
+        Err(ValidateError)
+    }
+}
+
+pub(crate) fn check_unary_operator_fn_params(
+    fn_: &FnDefinition,
+    context: &mut ValidateContext<'_>,
+    indexes: &Indexes<'_>,
+) -> Result<(), ValidateError> {
+    if !UNARY_OPERATOR_FN_NAMES.contains(&fn_.name.as_str()) || fn_.params.params.len() == 1 {
+        Ok(())
+    } else {
+        let fn_key = KeyRenderer::new(indexes).fn_key(fn_)?;
+        context.logs.push(Log {
+            level: LogLevel::Error,
+            msg: format!("`{fn_key}` unary operator function must have exactly one parameter"),
+            location: Some(context.location(fn_.signature_span)),
+            inner: vec![],
         });
         Err(ValidateError)
     }

--- a/tests/logs/error_operator_fns/.expected
+++ b/tests/logs/error_operator_fns/.expected
@@ -1,0 +1,4 @@
+error: `__neg__(i32, i32)` unary operator function must have exactly one parameter (at <root>/main__unary_operator_with_more_than_one_param__neg.gpex:1:4)
+error: `__not__(i32, i32)` unary operator function must have exactly one parameter (at <root>/main__unary_operator_with_more_than_one_param__not.gpex:1:4)
+error: `__neg__()` unary operator function must have exactly one parameter (at <root>/main__unary_operator_with_no_param__neg.gpex:1:4)
+error: `__not__()` unary operator function must have exactly one parameter (at <root>/main__unary_operator_with_no_param__not.gpex:1:4)

--- a/tests/logs/error_operator_fns/.expected
+++ b/tests/logs/error_operator_fns/.expected
@@ -1,4 +1,4 @@
-error: `__neg__(i32, i32)` unary operator function must have exactly one parameter (at <root>/main__unary_operator_with_more_than_one_param__neg.gpex:1:4)
-error: `__not__(i32, i32)` unary operator function must have exactly one parameter (at <root>/main__unary_operator_with_more_than_one_param__not.gpex:1:4)
-error: `__neg__()` unary operator function must have exactly one parameter (at <root>/main__unary_operator_with_no_param__neg.gpex:1:4)
-error: `__not__()` unary operator function must have exactly one parameter (at <root>/main__unary_operator_with_no_param__not.gpex:1:4)
+error: `__neg__(i32, i32)` unary operator function must have exactly one parameter (at <root>/main__unary_more_than_one_param__neg.gpex:1:4)
+error: `__not__(i32, i32)` unary operator function must have exactly one parameter (at <root>/main__unary_more_than_one_param__not.gpex:1:4)
+error: `__neg__()` unary operator function must have exactly one parameter (at <root>/main__unary_no_param__neg.gpex:1:4)
+error: `__not__()` unary operator function must have exactly one parameter (at <root>/main__unary_no_param__not.gpex:1:4)

--- a/tests/logs/error_operator_fns/cases.yaml
+++ b/tests/logs/error_operator_fns/cases.yaml
@@ -1,0 +1,16 @@
+# Test items with conflicting names.
+
+dimensions:
+  - id: operator_fn
+    cases:
+      unary_operator_with_no_param:
+        code: "fn {{fn.name}}() -> i32 { return 0; }"
+      unary_operator_with_more_than_one_param:
+        code: "fn {{fn.name}}(_param1: i32, _param2: i32) -> i32 { return 0; }"
+
+  - id: fn
+    cases:
+      neg:
+        name: "__neg__"
+      not:
+        name: "__not__"

--- a/tests/logs/error_operator_fns/cases.yaml
+++ b/tests/logs/error_operator_fns/cases.yaml
@@ -3,9 +3,9 @@
 dimensions:
   - id: operator_fn
     cases:
-      unary_operator_with_no_param:
+      unary_no_param:
         code: "fn {{fn.name}}() -> i32 { return 0; }"
-      unary_operator_with_more_than_one_param:
+      unary_more_than_one_param:
         code: "fn {{fn.name}}(_param1: i32, _param2: i32) -> i32 { return 0; }"
 
   - id: fn

--- a/tests/logs/error_operator_fns/cases.yaml
+++ b/tests/logs/error_operator_fns/cases.yaml
@@ -1,4 +1,4 @@
-# Test items with conflicting names.
+# Test operator function definitions.
 
 dimensions:
   - id: operator_fn

--- a/tests/logs/error_operator_fns/main__$$.gpex
+++ b/tests/logs/error_operator_fns/main__$$.gpex
@@ -1,0 +1,1 @@
+{{operator_fn.code}}

--- a/tests/logs/main.rs
+++ b/tests/logs/main.rs
@@ -81,6 +81,11 @@ fn compile_error_items_not_found_pub_in_priv_import() -> Result<(), Error> {
 }
 
 #[test]
+fn compile_error_operator_fns() -> Result<(), Error> {
+    compile_and_check_logs(Path::new("tests/logs/error_operator_fns"))
+}
+
+#[test]
 fn compile_error_out_of_bounds() -> Result<(), Error> {
     compile_and_check_logs(Path::new("tests/logs/error_out_of_bounds"))
 }


### PR DESCRIPTION
Part of #55 