### PR TITLE
Require unary operator functions to have a return type

### DIFF
--- a/src/compiler/validation/fns.rs
+++ b/src/compiler/validation/fns.rs
@@ -18,6 +18,11 @@ impl Validator<'_, '_> {
         self.validate_params(&node.params)?;
         self.validate_fn_return_type(node)?;
         validators::item::check_unary_operator_fn_params(node, &mut self.context, self.indexes)?;
+        validators::item::check_unary_operator_fn_return_type(
+            node,
+            &mut self.context,
+            self.indexes,
+        )?;
         self.run_with_fn_constness(node.const_keyword_span.is_some(), |self_| {
             self_.validate_fn_statements(node)
         })?;

--- a/src/compiler/validation/validators/item.rs
+++ b/src/compiler/validation/validators/item.rs
@@ -226,3 +226,22 @@ pub(crate) fn check_unary_operator_fn_params(
         Err(ValidateError)
     }
 }
+
+pub(crate) fn check_unary_operator_fn_return_type(
+    fn_: &FnDefinition,
+    context: &mut ValidateContext<'_>,
+    indexes: &Indexes<'_>,
+) -> Result<(), ValidateError> {
+    if !UNARY_OPERATOR_FN_NAMES.contains(&fn_.name.as_str()) || fn_.return_type.is_some() {
+        Ok(())
+    } else {
+        let fn_key = KeyRenderer::new(indexes).fn_key(fn_)?;
+        context.logs.push(Log {
+            level: LogLevel::Error,
+            msg: format!("`{fn_key}` unary operator function without return type"),
+            location: Some(context.location(fn_.signature_span)),
+            inner: vec![],
+        });
+        Err(ValidateError)
+    }
+}

--- a/tests/logs/error_operator_fns/.expected
+++ b/tests/logs/error_operator_fns/.expected
@@ -2,3 +2,5 @@ error: `__neg__(i32, i32)` unary operator function must have exactly one paramet
 error: `__not__(i32, i32)` unary operator function must have exactly one parameter (at <root>/main__unary_more_than_one_param__not.gpex:1:4)
 error: `__neg__()` unary operator function must have exactly one parameter (at <root>/main__unary_no_param__neg.gpex:1:4)
 error: `__not__()` unary operator function must have exactly one parameter (at <root>/main__unary_no_param__not.gpex:1:4)
+error: `__neg__(i32)` unary operator function without return type (at <root>/main__unary_no_return_type__neg.gpex:1:4)
+error: `__not__(i32)` unary operator function without return type (at <root>/main__unary_no_return_type__not.gpex:1:4)

--- a/tests/logs/error_operator_fns/cases.yaml
+++ b/tests/logs/error_operator_fns/cases.yaml
@@ -7,6 +7,8 @@ dimensions:
         code: "fn {{fn.name}}() -> i32 { return 0; }"
       unary_more_than_one_param:
         code: "fn {{fn.name}}(_param1: i32, _param2: i32) -> i32 { return 0; }"
+      unary_no_return_type:
+        code: "fn {{fn.name}}(_param: i32) { }"
 
   - id: fn
     cases:


### PR DESCRIPTION
Part of #55